### PR TITLE
Reuse values as far as possible

### DIFF
--- a/src/geometry.rs
+++ b/src/geometry.rs
@@ -1,58 +1,65 @@
 use std::fmt;
 use std::ops::{Add, Sub, Neg, Mul, Div};
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Vec3 {
     pub x: f64,
     pub y: f64,
     pub z: f64,
 }
 
-impl Add for Vec3 {
+impl <'a>Add<&'a Vec3> for Vec3 {
     type Output = Vec3;
 
-    fn add(self, other: Vec3) -> Vec3 {
-        Vec3 { x: self.x + other.x,
-               y: self.y + other.y,
-               z: self.z + other.z }
+    fn add(mut self, other: &'a Vec3) -> Vec3 {
+        self.x += other.x;
+        self.y += other.y;
+        self.z += other.z;
+        self
     }
 }
 
 impl Neg for Vec3 {
     type Output = Vec3;
 
-    fn neg(self) -> Vec3 {
-        Vec3 { x: -self.x,
-               y: -self.y,
-               z: -self.z }
+    fn neg(mut self) -> Vec3 {
+        self.x = -self.x;
+        self.y = -self.y;
+        self.z = -self.z;
+        self
     }
 }
 
-impl Sub for Vec3 {
+impl <'a>Sub<&'a Vec3> for Vec3 {
     type Output = Vec3;
 
-    fn sub(self, other: Vec3) -> Vec3 {
-        self + (-other)
+    fn sub(mut self, other: &'a Vec3) -> Vec3 {
+        self.x -= other.x;
+        self.y -= other.y;
+        self.z -= other.z;
+        self
     }
 }
 
 impl Mul<f64> for Vec3 {
     type Output = Vec3;
 
-    fn mul(self, other: f64) -> Vec3 {
-        Vec3 { x: self.x * other,
-               y: self.y * other,
-               z: self.z * other }
+    fn mul(mut self, other: f64) -> Vec3 {
+        self.x *= other;
+        self.y *= other;
+        self.z *= other;
+        self
     }
 }
 
 impl Mul<Vec3> for f64 {
     type Output = Vec3;
 
-    fn mul(self, other: Vec3) -> Vec3 {
-        Vec3 { x: self * other.x,
-               y: self * other.y,
-               z: self * other.z }
+    fn mul(self, mut other: Vec3) -> Vec3 {
+        other.x *= self;
+        other.y *= self;
+        other.z *= self;
+        other
     }
 }
 
@@ -73,16 +80,17 @@ impl Div<Vec3> for f64 {
 }
 
 impl Vec3 {
-    pub fn size(self) -> f64 {
+    pub fn size(&self) -> f64 {
         (self.x * self.x + self.y * self.y + self.z * self.z).sqrt()
     }
 
     pub fn normalize(self) -> Vec3 {
-        self / self.size()
+        let size = self.size();
+        self / size
     }
 }
 
-pub fn dot(lhs: Vec3, rhs: Vec3) -> f64 {
+pub fn dot(lhs: &Vec3, rhs: &Vec3) -> f64 {
     lhs.x * rhs.x + lhs.y * rhs.y + lhs.z * rhs.z
 }
 
@@ -92,7 +100,7 @@ impl fmt::Display for Vec3 {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub struct Ray {
     pub origin: Vec3,
     pub unit_dir: Vec3,

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,11 +14,11 @@ struct Env {
 }
 
 impl Env {
-    fn hit(&self, ray: &geometry::Ray) -> Option<obj::HitRecord> {
+    fn hit<'a>(&'a self, ray: &geometry::Ray) -> Option<obj::HitRecord<'a>> {
         // Is it impossible to use generics in closure?
         let take_min =
-            |a: Option<obj::HitRecord>,
-             b: Option<obj::HitRecord>| match (a, b) {
+            |a: Option<obj::HitRecord<'a>>,
+             b: Option<obj::HitRecord<'a>>| match (a, b) {
             (Some(a), Some(b)) => if a.t < b.t { Some(a) } else { Some(b) },
             (Some(a), None)    => Some(a),
             (None   , Some(b)) => Some(b),
@@ -42,7 +42,7 @@ impl Env {
             None      => (0, 0, 0),
             Some(hit) => {
                 match hit.material {
-                    obj::Material::Diffuse(r, g, b)  => {
+                    &obj::Material::Diffuse(r, g, b)  => {
                         // let power_directional = geometry::dot(hit.normal, self.directional_light).max(0.0);
 
                         let shadow = self.positional_light.origin.clone() - &hit.point;
@@ -63,7 +63,7 @@ impl Env {
                          (power_positional * (g as f64)) as i32,
                          (power_positional * (b as f64)) as i32)
                     },
-                    obj::Material::Specular => {
+                    &obj::Material::Specular => {
                         let dir = ray.unit_dir.clone() + &(2.0 * geometry::dot(&-ray.unit_dir.clone(), &hit.normal) * hit.normal);
                         let ray = geometry::Ray { unit_dir: dir, origin: hit.point };
                         self.trace(&ray, depth - 1)

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -30,11 +30,11 @@ pub fn plane_new(x: f64, y: f64, z: f64, d: f64, m: Material) -> Plane {
             material: m }
 }
 
-pub struct HitRecord {
+pub struct HitRecord<'a> {
     pub t: f64,
     pub normal: geometry::Vec3,
     pub point: geometry::Vec3,
-    pub material: Material
+    pub material: &'a Material
 }
 
 pub trait Hit {
@@ -61,7 +61,7 @@ impl Hit for Sphere {
                 Some(HitRecord { t: t,
                                  point: point + &(0.001 * normal.clone()),
                                  normal: normal,
-                                 material: self.material.clone() })
+                                 material: &self.material })
             }
         } else { None }
     }
@@ -77,7 +77,7 @@ impl Hit for Plane {
             Some(HitRecord{ t: t,
                             point: ray.origin.clone() + &(t * ray.unit_dir.clone()) + &(0.001 * self.normal.clone()),
                             normal: self.normal.clone(),
-                            material: self.material.clone() })
+                            material: &self.material })
         } else { None }
     }
 }

--- a/src/obj.rs
+++ b/src/obj.rs
@@ -1,6 +1,6 @@
 use geometry;
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 pub enum Material {
     Diffuse(i32, i32, i32),
     Specular
@@ -38,46 +38,46 @@ pub struct HitRecord {
 }
 
 pub trait Hit {
-    fn hit(&self, geometry::Ray) -> Option<HitRecord>;
+    fn hit(&self, &geometry::Ray) -> Option<HitRecord>;
 }
 
 impl Hit for Sphere {
-    fn hit(&self, ray: geometry::Ray) -> Option<HitRecord> {
-        let sray = self.origin - ray.origin;
-        
-        let det = geometry::dot(ray.unit_dir, sray).powi(2) - sray.size().powi(2) + self.radius.powi(2);
+    fn hit(&self, ray: &geometry::Ray) -> Option<HitRecord> {
+        let sray = self.origin.clone() - &ray.origin;
+
+        let det = geometry::dot(&ray.unit_dir, &sray).powi(2) - sray.size().powi(2) + self.radius.powi(2);
 
         if det >= 0.0 {
-            let t1 = geometry::dot(ray.unit_dir, sray) - det.sqrt();
-            let t2 = geometry::dot(ray.unit_dir, sray) + det.sqrt();
+            let t1 = geometry::dot(&ray.unit_dir, &sray) - det.sqrt();
+            let t2 = geometry::dot(&ray.unit_dir, &sray) + det.sqrt();
 
             if t2 < 0.0 {
                 None
             } else {
                 let t = if t1 >= 0.0 { t1 } else { t2 };
 
-                let point  = ray.origin + t * ray.unit_dir;
-                let normal = (point - self.origin).normalize();
+                let point  = ray.origin.clone() + &(t * ray.unit_dir.clone());
+                let normal = (point.clone() - &self.origin).normalize();
                 Some(HitRecord { t: t,
-                                 point: point + 0.001 * normal,
+                                 point: point + &(0.001 * normal.clone()),
                                  normal: normal,
-                                 material: self.material })
+                                 material: self.material.clone() })
             }
         } else { None }
     }
 }
 
 impl Hit for Plane {
-    fn hit(&self, ray: geometry::Ray) -> Option<HitRecord> {
+    fn hit(&self, ray: &geometry::Ray) -> Option<HitRecord> {
         let t =
-            (self.distance - geometry::dot(ray.origin, self.normal)) /
-            geometry::dot(ray.unit_dir, self.normal);
+            (self.distance - geometry::dot(&ray.origin, &self.normal)) /
+            geometry::dot(&ray.unit_dir, &self.normal);
 
         if t > 0.0 {
             Some(HitRecord{ t: t,
-                            point: ray.origin + t * ray.unit_dir + 0.001 * self.normal,
-                            normal: self.normal,
-                            material: self.material })
+                            point: ray.origin.clone() + &(t * ray.unit_dir.clone()) + &(0.001 * self.normal.clone()),
+                            normal: self.normal.clone(),
+                            material: self.material.clone() })
         } else { None }
     }
 }


### PR DESCRIPTION
This patch is just for your information. You may or may not merge this patch.

Unlike functional programming languages, Rust's memory allocation is slow so allocating and copying should be avoided as far as possible, especially in simulation code, that uses the same values in loops.

* Stop deriving copy on > 64bit data
* Use references as far as possible

this patch let your program render a image in 2.47s -> 2.00s on my laptop, debug build.

The compiler and the borrow checker may help you to reduce allocations.

